### PR TITLE
Disable snap for now

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -31,7 +31,7 @@ dmg:
 linux:
   target:
     - AppImage
-    - snap
+#    - snap
     - deb
   maintainer: electronjs.org
   category: Utility


### PR DESCRIPTION
The default github linux runner gives
```
  ⨯ snapcraft is not installed, please: sudo snap install snapcraft --classic 
```